### PR TITLE
feat!: Create source tag for generating release notes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     required: true
     description: Create a pre-release instead.
     default: 'false'
+  disable-source-tag:
+    required: true
+    description: Disable creating a source tag for generating release notes.
+    default: 'false'
   release-branch:
     required: true
     description: Branch name to place built artifacts on.


### PR DESCRIPTION
Now this action creates a source tag (`vx.y.z-src`) to generate release notes from the previous release correctly. This behaviour can be disabled using `disable-source-tag` option. Note that disabling that means automatic release notes will be also disabled.